### PR TITLE
chore: update dependencies and improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,7 +1,11 @@
-name: Build, Test, and Publish
-
+# Build, Test, and Publish
+#
+# - Runs on any push (any branch) and on pushed tags matching v*
+# - The publish step only runs when the ref is a tag that starts with "v"
 on:
   push:
+    branches:
+      - '**'
     tags:
       - 'v*'
 
@@ -11,12 +15,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -38,6 +44,7 @@ jobs:
         run: ./gradlew test
 
       - name: Publish to UTF MVN Repository
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
           UTF_MVN_USER: ${{ secrets.UTF_MVN_USER }}
           UTF_MVN_PASS: ${{ secrets.UTF_MVN_PASS }}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 06 18:41:36 BST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/minestom/build.gradle.kts
+++ b/minestom/build.gradle.kts
@@ -6,14 +6,13 @@ plugins {
 repositories {
     mavenCentral()
     maven { url = uri("https://mvn.utf.lol/releases") }
-    maven { url = uri("https://jitpack.io") }
     maven("https://repo.panda-lang.org/releases")
 }
 
 dependencies {
 
     compileOnly("net.minestom:minestom:2025.10.31-1.21.10")
-    compileOnly("com.github.TogAr2:MinestomPvP:56a831b41c")
+    compileOnly("io.github.togar2:MinestomPvP:60152fa5eb")
     api(project(":core"))
     compileOnly("org.readutf.buildformat:common:v2.0.10")
 


### PR DESCRIPTION
- Updated `io.github.togar2:MinestomPvP` dependency to a specific commit in `build.gradle.kts`.
- Removed unused JitPack repository.
- Upgraded Gradle wrapper to version 9.2.1.
- Enhanced GitHub Actions workflow:
  - Adjusted branch/tag triggers to match all pushes and version tags.
  - Added `fetch-depth: 0` for proper tag history in the checkout step.
  - Updated JDK version to 25 for consistency.
  - Added conditional publishing for versioned tags only.